### PR TITLE
fix for ftp bug 250 reported in wordmove.

### DIFF
--- a/lib/photocopier/ftp.rb
+++ b/lib/photocopier/ftp.rb
@@ -57,7 +57,8 @@ module Photocopier
     end
 
     def remote_ftp_url
-      url = options[:scheme].presence || "ftp"
+      url = ""
+      url << options[:scheme].presence || "ftp"
       url << "://"
       if options[:user].present?
         url << CGI.escape(options[:user])


### PR DESCRIPTION
Issue has been found when using wordmove and photocopier. Additional actions create additional loops through remote_ftp_url and the url being made contains parts from the previous action calls. 

added a simple url = "" to clear out anything at the start of the function call. Edited url = options[:scheme to url << options[:scheme to address my addition before it.
